### PR TITLE
Maker-Checker Submissions/Loans Routing

### DIFF
--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.html
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.html
@@ -186,7 +186,7 @@
         <button
           mat-raised-button
           color="primary"
-          [disabled]="!journalEntryForm.valid"
+          [disabled]="isSubmitting || !journalEntryForm.valid"
           *mifosxHasPermission="'CREATE_JOURNALENTRY'"
         >
           {{ 'labels.buttons.Submit' | translate }}

--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.ts
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, TemplateRef, ElementRef, ViewChild, AfterViewInit } 
 import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormArray } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 /** Custom Services */
 import { AccountingService } from '../accounting.service';
@@ -37,6 +38,8 @@ export class CreateJournalEntryComponent implements OnInit, AfterViewInit {
   /** Gl Account data. */
   glAccountData: any;
 
+  isSubmitting = false;
+
   /* Reference of create journal form */
   @ViewChild('createJournalFormRef') createJournalFormRef: ElementRef<any>;
   /* Template for popover on create journal form */
@@ -60,6 +63,7 @@ export class CreateJournalEntryComponent implements OnInit, AfterViewInit {
     private route: ActivatedRoute,
     private router: Router,
     private dialog: MatDialog,
+    private snackBar: MatSnackBar,
     private configurationWizardService: ConfigurationWizardService,
     private popoverService: PopoverService
   ) {
@@ -164,6 +168,9 @@ export class CreateJournalEntryComponent implements OnInit, AfterViewInit {
    * if successful redirects to view created transaction.
    */
   submit() {
+    if (this.isSubmitting) return;
+    this.isSubmitting = true;
+
     const journalEntry = this.journalEntryForm.value;
     // TODO: Update once language and date settings are setup
     journalEntry.locale = this.settingsService.language.code;
@@ -175,6 +182,16 @@ export class CreateJournalEntryComponent implements OnInit, AfterViewInit {
       );
     }
     this.accountingService.createJournalEntry(journalEntry).subscribe((response) => {
+      this.isSubmitting = false;
+
+      if (!response.transactionId) {
+        this.snackBar.open('Journal entry submitted for approval', 'Close', {
+          duration: 3000
+        });
+
+        this.router.navigate(['/accounting/journal-entries']);
+        return;
+      }
       this.router.navigate(
         [
           '../transactions/view',

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -138,6 +138,7 @@
             class="account-action-button"
             mat-raised-button
             color="primary"
+            (click)="navigateToApprove(element, $event)"
           >
             <i class="fa fa-check" matTooltip="{{ 'tooltips.Approve' | translate }}"></i>
           </button>
@@ -146,6 +147,7 @@
             class="account-action-button"
             mat-raised-button
             color="primary"
+            (click)="navigateToDisburse(element, $event)"
           >
             <i class="fa fa-flag" matTooltip="{{ 'tooltips.Disburse' | translate }}"></i>
           </button>

--- a/src/app/groups/groups-view/general-tab/general-tab.component.ts
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.ts
@@ -149,4 +149,36 @@ export class GeneralTabComponent {
       }
     );
   }
+
+  navigateToApprove(loan: any, $event: MouseEvent) {
+    $event.preventDefault();
+    $event.stopPropagation();
+
+    this.router.navigate(
+      [
+        '../',
+        'loans-accounts',
+        loan.id,
+        'actions',
+        'Approve'
+      ],
+      { relativeTo: this.route, state: { data: loan } }
+    );
+  }
+
+  navigateToDisburse(loan: any, $event: MouseEvent) {
+    $event.preventDefault();
+    $event.stopPropagation();
+
+    this.router.navigate(
+      [
+        '../',
+        'loans-accounts',
+        loan.id,
+        'actions',
+        'Disburse'
+      ],
+      { relativeTo: this.route, state: { data: loan } }
+    );
+  }
 }

--- a/src/app/loans/create-loans-account/create-loans-account.component.ts
+++ b/src/app/loans/create-loans-account/create-loans-account.component.ts
@@ -1,6 +1,7 @@
 /** Angular Imports */
 import { Component, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 /** Custom Services */
 import { LoansService } from '../loans.service';
@@ -58,6 +59,7 @@ export class CreateLoansAccountComponent {
     private router: Router,
     private loansService: LoansService,
     private settingsService: SettingsService,
+    private snackBar: MatSnackBar,
     private clientService: ClientsService
   ) {
     this.route.data.subscribe((data: { loansAccountTemplate: any }) => {
@@ -151,6 +153,18 @@ export class CreateLoansAccountComponent {
     }
 
     this.loansService.createLoansAccount(payload).subscribe((response: any) => {
+      if (!response.resourceId) {
+        this.snackBar.open('Loan Account submitted for approval', 'Close', {
+          duration: 3000
+        });
+        this.router.navigate(
+          [
+            '../../',
+            'general'
+          ],
+          { relativeTo: this.route }
+        );
+      }
       this.router.navigate(
         [
           '../',

--- a/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
@@ -99,7 +99,7 @@ export class LoanAccountActionsComponent {
     private route: ActivatedRoute,
     private router: Router
   ) {
-    this.navigationData = this.router.getCurrentNavigation().extras.state.data;
+    // this.navigationData = this.router.getCurrentNavigation().extras.state.data;
     this.route.data.subscribe((data: { actionButtonData: any }) => {
       this.actionButtonData = data.actionButtonData;
     });


### PR DESCRIPTION
## Description
Added a dialog on both Accounting/Loan creation for makers to be notified of their submissions instead of making many submissions without knowing
Corrected the routing for Loan Approvals/Disbursements action tabs on the General tab, it has been bringing a blank page on approval/Disbursement action tabs
